### PR TITLE
feat: hot module replacement feature

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     es6: true,
     node: true,
     jest: true,
+    browser: true,
   },
   plugins: ['prettier'],
   extends: ['@pitcher/eslint-config/javascript', 'prettier'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pitcher/watcher",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -884,6 +884,15 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -984,6 +993,11 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "astral-regex": {
       "version": "2.0.0",
@@ -1108,6 +1122,38 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "body-parser": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.1.tgz",
+      "integrity": "sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==",
+      "requires": {
+        "bytes": "3.1.1",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.8.1",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.9.6",
+        "raw-body": "2.4.2",
+        "type-is": "~1.6.18"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1168,6 +1214,11 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "bytes": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.1.tgz",
+      "integrity": "sha512-dWe4nWO/ruEOY7HkUJ5gFt1DCFV9zPRoJr8pV0/ASQermOZjtq8jMjOprC0Kd10GLN+l7xaUPvxzJFWtxGu8Fg=="
     },
     "callsites": {
       "version": "3.1.0",
@@ -1314,6 +1365,19 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "requires": {
+        "safe-buffer": "5.2.1"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
     "convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -1330,6 +1394,16 @@
           "dev": true
         }
       }
+    },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -1423,6 +1497,16 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -1461,6 +1545,11 @@
         }
       }
     },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
     "electron-to-chromium": {
       "version": "1.3.817",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.817.tgz",
@@ -1478,6 +1567,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
     "enquirer": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -1492,6 +1586,11 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1806,6 +1905,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -1848,6 +1952,58 @@
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
           "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
           "dev": true
+        }
+      }
+    },
+    "express": {
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.2.tgz",
+      "integrity": "sha512-oxlxJxcQlYwqPWKVJJtvQiwHgosH/LrLSPA+H4UxpyvSS6jC5aH+5MoHFM+KABgTOt0APue4w66Ha8jCUo9QGg==",
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.1",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.9.6",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.17.2",
+        "serve-static": "1.14.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -1919,6 +2075,35 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1955,6 +2140,16 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
+    },
+    "forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2073,6 +2268,18 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      }
+    },
     "http-proxy-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -2180,6 +2387,16 @@
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
       }
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -3004,11 +3221,26 @@
         "tmpl": "1.0.x"
       }
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
       "version": "4.0.4",
@@ -3020,17 +3252,20 @@
         "picomatch": "^2.2.3"
       }
     },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+    },
     "mime-db": {
       "version": "1.49.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
-      "dev": true
+      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA=="
     },
     "mime-types": {
       "version": "2.1.32",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
       "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
-      "dev": true,
       "requires": {
         "mime-db": "1.49.0"
       }
@@ -3071,6 +3306,11 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3108,6 +3348,14 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -3206,6 +3454,11 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
     },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3229,6 +3482,11 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "picomatch": {
       "version": "2.3.0",
@@ -3310,6 +3568,15 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "requires": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      }
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -3321,6 +3588,27 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "qs": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.2.tgz",
+      "integrity": "sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==",
+      "requires": {
+        "bytes": "3.1.1",
+        "http-errors": "1.8.1",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      }
     },
     "react-is": {
       "version": "17.0.2",
@@ -3456,6 +3744,64 @@
         "lru-cache": "^6.0.0"
       }
     },
+    "send": {
+      "version": "0.17.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
+      "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.8.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
+      "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.2"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -3571,6 +3917,11 @@
           "dev": true
         }
       }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "string-length": {
       "version": "4.0.2",
@@ -3750,6 +4101,11 @@
         "is-number": "^7.0.0"
       }
     },
+    "toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+    },
     "tough-cookie": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
@@ -3796,6 +4152,15 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -3811,6 +4176,11 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3824,6 +4194,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -3849,6 +4224,11 @@
           "dev": true
         }
       }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1005,6 +1005,14 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3289,11 +3297,18 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -3509,6 +3524,26 @@
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
+      }
+    },
+    "portfinder": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
+      "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
+      "requires": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
       }
     },
     "prelude-ls": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3101,6 +3101,12 @@
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
           "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
           "dev": true
+        },
+        "ws": {
+          "version": "7.5.7",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
+          "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+          "dev": true
         }
       }
     },
@@ -4377,10 +4383,9 @@
       }
     },
     "ws": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.3.tgz",
-      "integrity": "sha512-kQ/dHIzuLrS6Je9+uv81ueZomEwH0qVYstcAQ4/Z93K8zeko9gtAbttJWzoC5ukqXY1PpoouV3+VSOqEAFt5wg==",
-      "dev": true
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "portfinder": "^1.0.28"
   },
   "peerDependencies": {
-    "@vue/cli-service": "~4.3.0"
+    "@vue/cli-service": "~4.3.0",
+    "@pitcher/vue-cli-plugin-pitcherify": "~0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
   "dependencies": {
     "chalk": "^4.1.2",
     "chokidar": "^3.5.2",
+    "express": "^4.17.2",
     "inquirer": "^8.1.2",
+    "ip": "^1.1.5",
     "minimist": "^1.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "inquirer": "^8.1.2",
     "ip": "^1.1.5",
     "minimist": "^1.2.5",
-    "portfinder": "^1.0.28"
+    "portfinder": "^1.0.28",
+    "ws": "^8.5.0"
   },
   "peerDependencies": {
     "@vue/cli-service": "~4.3.0",

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "ip": "^1.1.5",
     "minimist": "^1.2.5",
     "portfinder": "^1.0.28"
+  },
+  "peerDependencies": {
+    "@vue/cli-service": "~4.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "express": "^4.17.2",
     "inquirer": "^8.1.2",
     "ip": "^1.1.5",
-    "minimist": "^1.2.5"
+    "minimist": "^1.2.5",
+    "portfinder": "^1.0.28"
   }
 }

--- a/src/hmr/hmr-helper-legacy.js
+++ b/src/hmr/hmr-helper-legacy.js
@@ -1,0 +1,193 @@
+/* eslint-disable prefer-template, prettier/prettier, no-var, consistent-return, object-shorthand, eqeqeq */
+
+/** Used for Legacy projects
+  * IMPORTANT NOTE: This file must to be ES5 compatible
+**/
+
+'use strict';
+
+/**************
+   Polyfills
+**************/
+
+// String.endsWith
+if (typeof String.prototype.endsWith !== 'function') {
+  String.prototype.endsWith = function(suffix) {
+    return this.indexOf(suffix, this.length - suffix.length) !== -1;
+  };
+}
+
+// String.includes
+if (typeof String.prototype.includes !== 'function') {
+  String.prototype.includes = function (str) {
+    var returnValue = false;
+
+    if (this.indexOf(str) !== -1) {
+      returnValue = true;
+    }
+
+    return returnValue;
+  }
+}
+
+// Array.find
+if (typeof Array.prototype.find !== 'function') {
+  Object.defineProperty(Array.prototype, 'find', {
+    
+    value: function(predicate) {
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+
+      var o = Object(this);
+      var len = o.length >>> 0;
+
+      if (typeof predicate !== 'function') {
+        throw new TypeError('predicate must be a function');
+      }
+
+      var thisArg = arguments[1];
+      var k = 0;
+
+      while (k < len) {
+        var kValue = o[k];
+
+        if (predicate.call(thisArg, kValue, k, o)) {
+          return kValue;
+        }
+        k++;
+      }
+
+      return undefined;
+    }
+  });
+}
+/*******************
+    END POLYFILLS
+*******************/
+
+function getScriptElement(el) {
+  var url = el.getAttribute('src');
+    
+    // replace all after ? char
+    url = url.replace(/\?.*/, '');
+  
+  var newScript = document.createElement('script');
+  
+  newScript.type = 'text/javascript';
+  newScript.src = url + '?updated=' + Date.now();
+
+  return newScript;
+}
+
+function getStyleElement(el) {
+  var url = el.getAttribute('href');
+  
+  // replace all after ? char
+  url = url.replace(/\?.*/, '');
+
+  var newStyle = document.createElement('link');
+  
+  newStyle.rel = 'stylesheet';
+  newStyle.href = url + '?updated=' + Date.now();
+
+  return newStyle;
+}
+
+// ES5 compatibilty
+function getAllLinks() {
+  var links = Array.prototype.slice.call(document.querySelectorAll('link'));
+
+  links = links.filter(function(el) {
+    if (!el.href.includes('interface_1')) {
+      return el;
+    }
+  })
+
+  return links;
+}
+
+// ES5 compatibilty
+function getAllScripts() {
+  var scripts = Array.prototype.slice.call(document.querySelectorAll('script'));
+  
+  scripts = scripts.filter(function(el) {
+    if (!el.src.includes('interface_1')) {
+      return el;
+    }
+  })
+
+  return scripts;
+}
+
+function reloadAssets(fileList) {
+  // get filtered links -> interface_1 links ignored
+  var links = getAllLinks();
+  // get filtered scripts -> interface_1 scripts ignored
+  var scripts = getAllScripts();
+
+  fileList.forEach(function (file) {
+    var el = null;
+
+    if (file.endsWith('.css')) {
+      el = links.find(function (link) {
+        return link.href.includes(file);
+      });
+
+      if (el) {
+        var newStyleElem = getStyleElement(el);
+        
+        el.parentNode.removeChild(el);
+        document.head.appendChild(newStyleElem);
+      }
+    } else if (file.endsWith('.js') || file.endsWith('.vj')) {
+      el = scripts.find(function (script) {
+        return script.src.includes(file);
+      });
+
+      if (el) {
+        var newScriptElem = getScriptElement(el)
+
+        el.parentNode.removeChild(el);
+        document.head.appendChild(newScriptElem);
+      }
+    } else if (file.endsWith('.html')) {
+      // if updated index.html, reload whole index
+      window.location.reload()
+    }
+  });
+}
+
+// Starting point
+
+var localIp = '{{HMR_LOCAL_IP}}';
+var port = '{{HMR_PORT}}';
+var mode = '{{HMR_MODE}}';
+
+if (!localIp) {
+  console.error('[@pitcher/watcher]: HMR is disabled, something is wrong with your ip adress!')
+}
+
+var WS_URL = 'ws://' + localIp + ':' + port;
+var socket = new WebSocket(WS_URL);
+
+socket.onopen = function () {
+  console.log('[@pitcher/watcher]: HMR enabled: ' + localIp + ':' + port + ', mode: ' + mode);
+};
+
+socket.onmessage = function (_ref) {
+  var data = _ref.data;
+
+  var res = JSON.parse(data);
+
+  if (res.event === 'HOT_RELOAD') {
+    console.log('[@pitcher/watcher]: page updated');
+    reloadAssets(res.files);
+  } else if (res.event === 'LIVE_RELOAD') {
+    window.location.reload();
+  }
+};
+
+socket.onclose = function () {
+  console.error('[@pitcher/watcher]: HMR connection closed!');
+};

--- a/src/hmr/hmr-helper-legacy.js
+++ b/src/hmr/hmr-helper-legacy.js
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-template, prettier/prettier, no-var, consistent-return, object-shorthand, eqeqeq */
 
 /** Used for Legacy projects
-  * IMPORTANT NOTE: This file must to be ES5 compatible
+  * IMPORTANT NOTE: This file must be ES5 compatible
 **/
 
 'use strict';

--- a/src/hmr/hmr-helper.js
+++ b/src/hmr/hmr-helper.js
@@ -63,7 +63,7 @@ if (process.env.VUE_APP_HMR) {
   var socket = new WebSocket(WS_URL);
   
   socket.onopen = function () {
-    console.log('[@pitcher/watcher]: HMR enabled in port: ' + process.env.VUE_APP_HMR_PORT + ', mode: ' + process.env.VUE_APP_HMR_MODE);
+    console.log('[@pitcher/watcher]: HMR enabled: ' + localIp + ':' + port + ', mode: ' + process.env.VUE_APP_HMR_MODE);
   };
   
   socket.onmessage = function (_ref) {

--- a/src/hmr/hmr-helper.js
+++ b/src/hmr/hmr-helper.js
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-template, prettier/prettier, no-var */
 
-/** IMPORTANT
-  * NOTE: This file must to be ES5 compatible
+/** Used for Vue based projects
+  * IMPORTANT NOTE: This file must to be ES5 compatible
 **/
 
 'use strict';

--- a/src/hmr/hmr-helper.js
+++ b/src/hmr/hmr-helper.js
@@ -44,7 +44,9 @@ if (process.env.VUE_APP_HMR) {
   const socket = new WebSocket(WS_URL)
 
   socket.onopen = () => {
-    console.log(`[@pitcher/watcher]: HMR enabled in port: ${process.env.VUE_APP_HMR_PORT}`)
+    console.log(
+      `[@pitcher/watcher]: HMR enabled in port: ${process.env.VUE_APP_HMR_PORT}, mode: ${process.env.VUE_APP_HMR_MODE}`
+    )
   }
 
   socket.onmessage = ({ data }) => {

--- a/src/hmr/hmr-helper.js
+++ b/src/hmr/hmr-helper.js
@@ -1,0 +1,112 @@
+function removeCurrentFiles(fileList) {
+  const links = Array.from(document.querySelectorAll('link'))
+  const scripts = Array.from(document.querySelectorAll('script'))
+
+  fileList.forEach((file) => {
+    let el = null
+
+    if (file.endsWith('.css')) {
+      el = links.find((link) => link.href.includes(file))
+    } else if (file.endsWith('.js')) {
+      el = scripts.find((script) => script.src.includes(file))
+    }
+
+    if (el) {
+      el.parentNode.removeChild(el)
+    }
+  })
+}
+
+function injectNewFiles(fileList) {
+  fileList.forEach((file) => {
+    let newElement = null
+    const url = `${file}?updated=${Date.now()}`
+
+    if (file.endsWith('.css')) {
+      newElement = document.createElement('link')
+      newElement.rel = 'stylesheet'
+      newElement.href = url
+      document.head.appendChild(newElement)
+    }
+    if (file.endsWith('.js')) {
+      newElement = document.createElement('script')
+      newElement.type = 'text/javascript'
+      newElement.src = file
+      document.body.appendChild(newElement)
+    }
+  })
+}
+
+// Starting point
+
+if (process.env.VUE_APP_HMR) {
+  const WS_URL = `ws://localhost:${process.env.VUE_APP_HMR_PORT || 8099}`
+  const socket = new WebSocket(WS_URL)
+
+  socket.onopen = () => {
+    console.log(`[@pitcher/watcher]: HMR enabled in port: ${process.env.VUE_APP_HMR_PORT}`)
+  }
+
+  socket.onmessage = ({ data }) => {
+    const res = JSON.parse(data)
+
+    if (res.event === 'HOT_RELOAD') {
+      console.log('[@pitcher/watcher]: page updated')
+      removeCurrentFiles(res.files.current)
+      injectNewFiles(res.files.updated)
+    } else if (res.event === 'LIVE_RELOAD') {
+      window.location.reload()
+    }
+  }
+
+  socket.onclose = () => {
+    console.error('[@pitcher/watcher]: HMR connection closed!')
+  }
+}
+
+// export const useHotModule = (fileNames) => {
+//   const scriptsArray = Array.from(document.scripts)
+
+//   let foundScripts = []
+
+//   fileNames.forEach((name) => {
+//     const found = scriptsArray.filter((el) => el.src.includes(name))
+
+//     if (!found) return
+
+//     found.forEach((script) => {
+//       foundScripts.push(script)
+//     })
+//   })
+
+//   foundScripts = Array.from(new Set(foundScripts.map((item) => item)))
+
+//   foundScripts.forEach((script) => {
+//     const parentContainer = script.parentNode
+//     const src = `${script.getAttribute('src')}?updated=${Date.now()}`
+
+//     script.remove()
+
+//     const newScript = document.createElement('script')
+
+//     newScript.src = src
+//     newScript.type = 'text/javascript'
+//     parentContainer.appendChild(newScript)
+//   })
+// }
+
+// Singular example
+// export const useHotModule = (fileNames) => {
+//   const scriptsArray = Array.from(document.scripts)
+//   const foundScript = scriptsArray.find((el) => el.src.includes(fileNames))
+//   const parentContainer = foundScript.parentNode
+
+//   const src = `${foundScript.getAttribute('src')}?updated=${Date.now()}`
+//   const newScript = document.createElement('script')
+
+//   foundScript.remove()
+
+//   newScript.src = src
+//   newScript.type = 'text/javascript'
+//   parentContainer.appendChild(newScript)
+// }

--- a/src/hmr/hmr-helper.js
+++ b/src/hmr/hmr-helper.js
@@ -1,7 +1,7 @@
 /* eslint-disable prefer-template, prettier/prettier, no-var */
 
 /** Used for Vue based projects
-  * IMPORTANT NOTE: This file must to be ES5 compatible
+  * IMPORTANT NOTE: This file must be ES5 compatible
 **/
 
 'use strict';

--- a/src/hmr/hmr-helper.js
+++ b/src/hmr/hmr-helper.js
@@ -1,6 +1,6 @@
 /* eslint-disable prefer-template, prettier/prettier, no-var */
 
-/**
+/** IMPORTANT
   * NOTE: This file must to be ES5 compatible
 **/
 

--- a/src/hmr/hmr-helper.js
+++ b/src/hmr/hmr-helper.js
@@ -1,114 +1,86 @@
-function removeCurrentFiles(fileList) {
-  const links = Array.from(document.querySelectorAll('link'))
-  const scripts = Array.from(document.querySelectorAll('script'))
+/* eslint-disable prefer-template, prettier/prettier, no-var */
 
-  fileList.forEach((file) => {
-    let el = null
+/**
+  * NOTE: This file must to be ES5 compatible
+**/
+
+'use strict';
+
+function removeCurrentFiles(fileList) {
+  var links = Array.from(document.querySelectorAll('link'));
+  var scripts = Array.from(document.querySelectorAll('script'));
+
+  fileList.forEach(function (file) {
+    var el = null;
 
     if (file.endsWith('.css')) {
-      el = links.find((link) => link.href.includes(file))
+      el = links.find(function (link) {
+        return link.href.includes(file);
+      });
     } else if (file.endsWith('.js')) {
-      el = scripts.find((script) => script.src.includes(file))
+      el = scripts.find(function (script) {
+        return script.src.includes(file);
+      });
     }
 
     if (el) {
-      el.parentNode.removeChild(el)
+      el.parentNode.removeChild(el);
     }
-  })
+  });
 }
 
 function injectNewFiles(fileList) {
-  fileList.forEach((file) => {
-    let newElement = null
-    const url = `${file}?updated=${Date.now()}`
+  fileList.forEach(function (file) {
+    var newElement = null;
+    var url = file + '?updated=' + Date.now();
 
     if (file.endsWith('.css')) {
-      newElement = document.createElement('link')
-      newElement.rel = 'stylesheet'
-      newElement.href = url
-      document.head.appendChild(newElement)
+      newElement = document.createElement('link');
+      newElement.rel = 'stylesheet';
+      newElement.href = url;
+      document.head.appendChild(newElement);
     }
     if (file.endsWith('.js')) {
-      newElement = document.createElement('script')
-      newElement.type = 'text/javascript'
-      newElement.src = file
-      document.body.appendChild(newElement)
+      newElement = document.createElement('script');
+      newElement.type = 'text/javascript';
+      newElement.src = file;
+      document.body.appendChild(newElement);
     }
-  })
+  });
 }
 
 // Starting point
 
 if (process.env.VUE_APP_HMR) {
-  const WS_URL = `ws://localhost:${process.env.VUE_APP_HMR_PORT || 8099}`
-  const socket = new WebSocket(WS_URL)
+  var localIp = process.env.VUE_APP_HMR_IP
+  var port = process.env.VUE_APP_HMR_PORT || 8099
 
-  socket.onopen = () => {
-    console.log(
-      `[@pitcher/watcher]: HMR enabled in port: ${process.env.VUE_APP_HMR_PORT}, mode: ${process.env.VUE_APP_HMR_MODE}`
-    )
+  if (!localIp) {
+    console.error('[@pitcher/watcher]: HMR is disabled, something is wrong with your ip adress!')
   }
 
-  socket.onmessage = ({ data }) => {
-    const res = JSON.parse(data)
+  var WS_URL = 'ws://' + localIp + ':' + port;
+  var socket = new WebSocket(WS_URL);
+  
+  socket.onopen = function () {
+    console.log('[@pitcher/watcher]: HMR enabled in port: ' + process.env.VUE_APP_HMR_PORT + ', mode: ' + process.env.VUE_APP_HMR_MODE);
+  };
+  
+  socket.onmessage = function (_ref) {
+    var data = _ref.data;
+
+    var res = JSON.parse(data);
 
     if (res.event === 'HOT_RELOAD') {
-      console.log('[@pitcher/watcher]: page updated')
-      removeCurrentFiles(res.files.current)
-      injectNewFiles(res.files.updated)
+      console.log('[@pitcher/watcher]: page updated');
+      removeCurrentFiles(res.files.current);
+      injectNewFiles(res.files.updated);
     } else if (res.event === 'LIVE_RELOAD') {
-      window.location.reload()
+      window.location.reload();
     }
-  }
+  };
 
-  socket.onclose = () => {
-    console.error('[@pitcher/watcher]: HMR connection closed!')
-  }
+  socket.onclose = function () {
+    console.error('[@pitcher/watcher]: HMR connection closed!');
+  };
 }
-
-// export const useHotModule = (fileNames) => {
-//   const scriptsArray = Array.from(document.scripts)
-
-//   let foundScripts = []
-
-//   fileNames.forEach((name) => {
-//     const found = scriptsArray.filter((el) => el.src.includes(name))
-
-//     if (!found) return
-
-//     found.forEach((script) => {
-//       foundScripts.push(script)
-//     })
-//   })
-
-//   foundScripts = Array.from(new Set(foundScripts.map((item) => item)))
-
-//   foundScripts.forEach((script) => {
-//     const parentContainer = script.parentNode
-//     const src = `${script.getAttribute('src')}?updated=${Date.now()}`
-
-//     script.remove()
-
-//     const newScript = document.createElement('script')
-
-//     newScript.src = src
-//     newScript.type = 'text/javascript'
-//     parentContainer.appendChild(newScript)
-//   })
-// }
-
-// Singular example
-// export const useHotModule = (fileNames) => {
-//   const scriptsArray = Array.from(document.scripts)
-//   const foundScript = scriptsArray.find((el) => el.src.includes(fileNames))
-//   const parentContainer = foundScript.parentNode
-
-//   const src = `${foundScript.getAttribute('src')}?updated=${Date.now()}`
-//   const newScript = document.createElement('script')
-
-//   foundScript.remove()
-
-//   newScript.src = src
-//   newScript.type = 'text/javascript'
-//   parentContainer.appendChild(newScript)
-// }

--- a/src/hmr/index.js
+++ b/src/hmr/index.js
@@ -1,4 +1,5 @@
 const startServer = require('./socket-server')
+const ip = require('ip')
 
 const pluginName = 'PitcherWatcherPlugin'
 
@@ -20,6 +21,7 @@ class PitcherWatcherPlugin {
     if (this.isLiveOrHot) {
       process.env.VUE_APP_HMR = true
       process.env.VUE_APP_HMR_MODE = this.mode
+      process.env.VUE_APP_HMR_IP = ip.address()
       process.env.VUE_APP_HMR_PORT = this.port
 
       // sets server and wss

--- a/src/hmr/index.js
+++ b/src/hmr/index.js
@@ -18,7 +18,7 @@ class PitcherWatcherPlugin {
     this.isLiveOrHot = ['hot', 'live'].includes(this.mode)
     // server & websocket instances set by useHMR function
     this.server = undefined
-    this.wss = undefined
+    this.ws = undefined
 
     // bundle files (js/css)
     this.files = {
@@ -32,7 +32,7 @@ class PitcherWatcherPlugin {
       process.env.VUE_APP_HMR_IP = this.ip
       process.env.VUE_APP_HMR_PORT = this.port
 
-      // sets server and wss
+      // sets server and web sockets
       this.useHMR()
     }
   }
@@ -63,7 +63,7 @@ class PitcherWatcherPlugin {
       this.files.updated = filteredFiles
 
       // Send message to each client
-      this.wss.clients.forEach((client) => {
+      this.ws.clients.forEach((client) => {
         if (this.mode === 'hot') {
           client.send(JSON.stringify({ event: 'HOT_RELOAD', files: this.files }))
 
@@ -77,10 +77,10 @@ class PitcherWatcherPlugin {
     })
   }
   useHMR() {
-    const { server, wss } = startServer(this.port)
+    const { server, ws } = startServer(this.port)
 
     this.server = server
-    this.wss = wss
+    this.ws = ws
   }
 }
 

--- a/src/hmr/index.js
+++ b/src/hmr/index.js
@@ -1,0 +1,76 @@
+const startServer = require('./socket-server')
+
+const pluginName = 'PitcherWatcherPlugin'
+
+class PitcherWatcherPlugin {
+  constructor(options = {}) {
+    // parse options
+    this.port = options.port
+    this.mode = options.mode || 'hot'
+    this.destination = options.destination
+    this.server = undefined
+    this.wss = undefined
+    this.isLiveOrHot = ['hot', 'live'].includes(this.mode)
+
+    this.files = {
+      current: [],
+      updated: [],
+    }
+
+    if (this.isLiveOrHot) {
+      process.env.VUE_APP_HMR = true
+      process.env.VUE_APP_HMR_PORT = this.port
+
+      // sets server and wss
+      this.useHMR()
+    }
+  }
+
+  apply(compiler) {
+    // do not continue if mode is not hot or live
+    if (!this.isLiveOrHot) return
+
+    // HMR helper for consumer project, inject WebSocket file to listen events
+    compiler.hooks.entryOption.tap(pluginName, (ctx, entry) => {
+      if (process.env.NODE_ENV === 'development') {
+        entry.hmr_helper = ['@pitcher/watcher/src/hmr/hmr-helper.js']
+      }
+    })
+
+    const extensions = ['.js', '.css']
+    const blocked = ['hmr_helper', 'polyfill', 'chunk-vendors']
+
+    // Emit global message through Node.js when compiled
+    compiler.hooks.done.tap(pluginName, (stats) => {
+      const bundleFiles = Array.from(stats.compilation.assetsInfo.keys())
+
+      const filteredFiles = bundleFiles
+        .filter((fileName) => extensions.some((ext) => fileName.endsWith(ext)))
+        .filter((fileName) => blocked.every((str) => !fileName.includes(str)))
+
+      // save updated files first
+      this.files.updated = filteredFiles
+
+      // Send message to each client
+      this.wss.clients.forEach((client) => {
+        if (this.mode === 'hot') {
+          client.send(JSON.stringify({ event: 'HOT_RELOAD', files: this.files }))
+
+          return
+        }
+        client.send(JSON.stringify({ event: 'LIVE_RELOAD' }))
+      })
+
+      // save updated files as current after sending message to all clients
+      this.files.current = filteredFiles
+    })
+  }
+  useHMR() {
+    const { server, wss } = startServer(this.port)
+
+    this.server = server
+    this.wss = wss
+  }
+}
+
+module.exports = PitcherWatcherPlugin

--- a/src/hmr/index.js
+++ b/src/hmr/index.js
@@ -19,6 +19,7 @@ class PitcherWatcherPlugin {
 
     if (this.isLiveOrHot) {
       process.env.VUE_APP_HMR = true
+      process.env.VUE_APP_HMR_MODE = this.mode
       process.env.VUE_APP_HMR_PORT = this.port
 
       // sets server and wss

--- a/src/hmr/index.js
+++ b/src/hmr/index.js
@@ -5,13 +5,12 @@
 **/
 
 const startServer = require('./socket-server')
-const ip = require('ip')
-
 const pluginName = 'PitcherWatcherPlugin'
 
 class PitcherWatcherPlugin {
   constructor(options = {}) {
     // parse options
+    this.ip = options.ip
     this.port = options.port
     this.mode = options.mode || 'hot'
     // destination of project files
@@ -30,7 +29,7 @@ class PitcherWatcherPlugin {
     if (this.isLiveOrHot) {
       process.env.VUE_APP_HMR = true
       process.env.VUE_APP_HMR_MODE = this.mode
-      process.env.VUE_APP_HMR_IP = ip.address()
+      process.env.VUE_APP_HMR_IP = this.ip
       process.env.VUE_APP_HMR_PORT = this.port
 
       // sets server and wss

--- a/src/hmr/index.js
+++ b/src/hmr/index.js
@@ -1,3 +1,9 @@
+/**
+|--------------------------------------------------
+| Pitcher Watcher Webpack Plugin
+|--------------------------------------------------
+**/
+
 const startServer = require('./socket-server')
 const ip = require('ip')
 
@@ -8,11 +14,14 @@ class PitcherWatcherPlugin {
     // parse options
     this.port = options.port
     this.mode = options.mode || 'hot'
+    // destination of project files
     this.destination = options.destination
+    this.isLiveOrHot = ['hot', 'live'].includes(this.mode)
+    // server & websocket instances set by useHMR function
     this.server = undefined
     this.wss = undefined
-    this.isLiveOrHot = ['hot', 'live'].includes(this.mode)
 
+    // bundle files (js/css)
     this.files = {
       current: [],
       updated: [],

--- a/src/hmr/legacy-hmr.js
+++ b/src/hmr/legacy-hmr.js
@@ -49,10 +49,10 @@ const useHtmlInject = async (hmr, destination) => {
 // parses file name from full file path
 const parseFileName = (path) => path.substring(path.lastIndexOf('/') + 1)
 
-const emitChangesToClients = (wss, mode, changedFiles) => {
+const emitChangesToClients = (ws, mode, changedFiles) => {
   const filesToEmit = Array.from(changedFiles).map((p) => parseFileName(p))
 
-  wss.clients.forEach((client) => {
+  ws.clients.forEach((client) => {
     if (mode === 'hot') {
       client.send(JSON.stringify({ event: 'HOT_RELOAD', files: filesToEmit }))
 

--- a/src/hmr/legacy-hmr.js
+++ b/src/hmr/legacy-hmr.js
@@ -1,0 +1,68 @@
+const path = require('path')
+const { parseHTML } = require('linkedom')
+const { readFile, writeFile } = require('fs/promises')
+const { dirExist } = require('../utils/file-system')
+const { warn } = require('../utils/logger')
+
+const copyHMRHelper = async (hmr, destination) => {
+  // read local JS template file
+  const legacyHelperPath = path.join(__dirname, 'hmr-helper-legacy.js')
+
+  // read legacy helper file
+  let rawHelperFile = await readFile(legacyHelperPath, { encoding: 'utf-8' })
+
+  // replace dynamic variables
+  rawHelperFile = rawHelperFile.replace('{{HMR_LOCAL_IP}}', hmr.ip)
+  rawHelperFile = rawHelperFile.replace('{{HMR_PORT}}', hmr.port)
+  rawHelperFile = rawHelperFile.replace('{{HMR_MODE}}', hmr.mode)
+
+  await writeFile(`${destination}/hmr-helper-legacy.js`, rawHelperFile)
+}
+
+const injectHelperToHTML = async (destination) => {
+  const indexHtmlPath = `${destination}/index.html`
+
+  if (!dirExist(indexHtmlPath)) {
+    warn(`index.html in destination path could not be found! HMR is not active...`)
+
+    return
+  }
+
+  const htmlFile = await readFile(indexHtmlPath, { encoding: 'utf-8' })
+
+  // NOTE: document is not global
+  const { document } = parseHTML(htmlFile)
+  const helperScript = document.createElement('script')
+
+  helperScript.setAttribute('src', 'hmr-helper-legacy.js')
+  helperScript.setAttribute('type', 'text/javascript')
+  document.head.appendChild(helperScript)
+
+  await writeFile(`${destination}/index.html`, document.toString())
+}
+
+const useHtmlInject = async (hmr, destination) => {
+  await copyHMRHelper(hmr, destination)
+  await injectHelperToHTML(destination)
+}
+
+// parses file name from full file path
+const parseFileName = (path) => path.substring(path.lastIndexOf('/') + 1)
+
+const emitChangesToClients = (wss, mode, changedFiles) => {
+  wss.clients.forEach((client) => {
+    if (mode === 'hot') {
+      const filesToEmit = Array.from(changedFiles).map((p) => parseFileName(p))
+
+      client.send(JSON.stringify({ event: 'HOT_RELOAD', files: filesToEmit }))
+
+      return
+    }
+    client.send(JSON.stringify({ event: 'LIVE_RELOAD' }))
+  })
+}
+
+module.exports = {
+  useHtmlInject,
+  emitChangesToClients,
+}

--- a/src/hmr/legacy-hmr.js
+++ b/src/hmr/legacy-hmr.js
@@ -50,10 +50,10 @@ const useHtmlInject = async (hmr, destination) => {
 const parseFileName = (path) => path.substring(path.lastIndexOf('/') + 1)
 
 const emitChangesToClients = (wss, mode, changedFiles) => {
+  const filesToEmit = Array.from(changedFiles).map((p) => parseFileName(p))
+
   wss.clients.forEach((client) => {
     if (mode === 'hot') {
-      const filesToEmit = Array.from(changedFiles).map((p) => parseFileName(p))
-
       client.send(JSON.stringify({ event: 'HOT_RELOAD', files: filesToEmit }))
 
       return

--- a/src/hmr/socket-server.js
+++ b/src/hmr/socket-server.js
@@ -1,0 +1,36 @@
+const http = require('http')
+const WebSocket = require('ws')
+const express = require('express')
+const { log } = require('../utils/logger')
+
+const startServer = (port) => {
+  /*
+      TO DO:
+      check port first if available
+      https://github.com/http-party/node-portfinder
+  */
+  const app = express()
+
+  app.get('/', (req, res) => {
+    res.set('Content-Type', 'text/html')
+    res.send(Buffer.from('<h2>Pitcher Watcher HMR</h2>'))
+  })
+
+  const server = http.createServer(app)
+  const wss = new WebSocket.Server({ server })
+
+  // wss.on('connection', (ws) => {
+  //   ws.on('message', (msg) => {
+  //     // received message
+  //     console.log('received: %s', msg)
+  //   })
+  // })
+
+  server.listen(port, () => {
+    log(`HMR Server listening on port: ${server.address().port}`)
+  })
+
+  return { wss, server }
+}
+
+module.exports = startServer

--- a/src/hmr/socket-server.js
+++ b/src/hmr/socket-server.js
@@ -12,13 +12,13 @@ const startServer = (port) => {
   })
 
   const server = http.createServer(app)
-  const wss = new WebSocket.Server({ server })
+  const ws = new WebSocket.Server({ server })
 
   server.listen(port, () => {
     clog('\n[@pitcher/watcher]:', 'white', `HMR Server running on port: ${server.address().port}`, 'cyan')
   })
 
-  return { server, wss }
+  return { server, ws }
 }
 
 module.exports = startServer

--- a/src/hmr/socket-server.js
+++ b/src/hmr/socket-server.js
@@ -14,6 +14,7 @@ const startServer = (port) => {
   const server = http.createServer(app)
   const wss = new WebSocket.Server({ server })
 
+  // Example of wss listener
   // wss.on('connection', (ws) => {
   //   ws.on('message', (msg) => {
   //     // received message

--- a/src/hmr/socket-server.js
+++ b/src/hmr/socket-server.js
@@ -14,14 +14,6 @@ const startServer = (port) => {
   const server = http.createServer(app)
   const wss = new WebSocket.Server({ server })
 
-  // Example of wss listener
-  // wss.on('connection', (ws) => {
-  //   ws.on('message', (msg) => {
-  //     // received message
-  //     console.log('received: %s', msg)
-  //   })
-  // })
-
   server.listen(port, () => {
     clog('\n[@pitcher/watcher]:', 'white', `HMR Server running on port: ${server.address().port}`, 'cyan')
   })

--- a/src/hmr/socket-server.js
+++ b/src/hmr/socket-server.js
@@ -1,14 +1,24 @@
 const http = require('http')
 const WebSocket = require('ws')
 const express = require('express')
-const { log } = require('../utils/logger')
+const portfinder = require('portfinder')
+const { log, error } = require('../utils/logger')
 
-const startServer = (port) => {
-  /*
-      TO DO:
-      check port first if available
-      https://github.com/http-party/node-portfinder
-  */
+// eslint-disable-next-line consistent-return
+const getFreePort = async (port) => {
+  try {
+    return await portfinder.getPortPromise({
+      port, // minimum port
+      stopPort: port + 1000, // maximum port
+    })
+  } catch (e) {
+    error('[ERROR]: Something went wrong when trying to find a free port for HMR server!')
+    error(e)
+  }
+}
+
+const startServer = async (_port) => {
+  const port = await getFreePort(_port)
   const app = express()
 
   app.get('/', (req, res) => {
@@ -27,10 +37,10 @@ const startServer = (port) => {
   // })
 
   server.listen(port, () => {
-    log(`HMR Server listening on port: ${server.address().port}`)
+    log(`HMR Server running on port: ${server.address().port}`)
   })
 
-  return { wss, server }
+  return { port, server, wss }
 }
 
 module.exports = startServer

--- a/src/hmr/socket-server.js
+++ b/src/hmr/socket-server.js
@@ -1,24 +1,9 @@
 const http = require('http')
 const WebSocket = require('ws')
 const express = require('express')
-const portfinder = require('portfinder')
-const { log, error } = require('../utils/logger')
+const { clog } = require('../utils/logger')
 
-// eslint-disable-next-line consistent-return
-const getFreePort = async (port) => {
-  try {
-    return await portfinder.getPortPromise({
-      port, // minimum port
-      stopPort: port + 1000, // maximum port
-    })
-  } catch (e) {
-    error('[ERROR]: Something went wrong when trying to find a free port for HMR server!')
-    error(e)
-  }
-}
-
-const startServer = async (_port) => {
-  const port = await getFreePort(_port)
+const startServer = (port) => {
   const app = express()
 
   app.get('/', (req, res) => {
@@ -37,10 +22,10 @@ const startServer = async (_port) => {
   // })
 
   server.listen(port, () => {
-    log(`HMR Server running on port: ${server.address().port}`)
+    clog('\n[@pitcher/watcher]:', 'white', `HMR Server running on port: ${server.address().port}`, 'cyan')
   })
 
-  return { port, server, wss }
+  return { server, wss }
 }
 
 module.exports = startServer

--- a/src/init.js
+++ b/src/init.js
@@ -23,8 +23,8 @@ const validateCommonArgs = () => {
   }
 
   // check mode
-  if (args.watchMode && !['hot', 'live', 'redirect', 'manual'].includes(args.watchMode)) {
-    warn(`[WARNING]: --watchMode=${args.watchMode} is invalid. Available arguments hot, live, redirect, manual`)
+  if (args.watchMode && !['hot', 'live', 'manual'].includes(args.watchMode)) {
+    warn(`[WARNING]: --watchMode=${args.watchMode} is invalid. Available arguments hot, live, manual`)
     warn('[WARNING]: defaulting watchMode to: hot')
     args.watchMode = 'hot'
   }

--- a/src/init.js
+++ b/src/init.js
@@ -1,5 +1,7 @@
+const ip = require('ip')
 const args = require('minimist')(process.argv.slice(2))
 const { log, clog, error, warn } = require('./utils/logger')
+const getFreePort = require('./utils/port-finder')
 
 let shouldExit = false
 
@@ -90,7 +92,7 @@ const showHelp = (type) => {
 }
 
 // Starting point
-const initialize = (type = 'vue') => {
+const initialize = async (type = 'vue') => {
   if (args.h || args.help) {
     showHelp(type)
     process.exit()
@@ -106,8 +108,15 @@ const initialize = (type = 'vue') => {
     dest: args.dest !== undefined ? args.dest : undefined,
     hmr: {
       mode: args.watchMode || 'hot',
-      wsport: args.wsport || 8099,
+      port: args.wsport || 8099,
+      ip: undefined,
     },
+  }
+
+  // set port & ip address if HMR is active
+  if (['hot', 'live'].includes(parsedArgs.hmr.mode)) {
+    parsedArgs.hmr.port = await getFreePort(parsedArgs.hmr.port)
+    parsedArgs.hmr.ip = ip.address()
   }
 
   /* Vue watcher */

--- a/src/init.js
+++ b/src/init.js
@@ -1,5 +1,5 @@
 const args = require('minimist')(process.argv.slice(2))
-const { log, clog, error } = require('./utils/logger')
+const { log, clog, error, warn } = require('./utils/logger')
 
 let shouldExit = false
 
@@ -20,6 +20,13 @@ const validateCommonArgs = () => {
   } else if (args && args.platform && !supportedPlatforms.includes(args.platform)) {
     error(`[ERROR]: Platform ${args.platform} is not supported!`)
     shouldExit = true
+  }
+
+  // check mode
+  if (args.mode && !['hot', 'live', 'redirect', 'manual'].includes(args.mode)) {
+    warn(`[WARNING]: --mode=${args.mode} is invalid. Available arguments hot, live, redirect, manual`)
+    warn('[WARNING]: defaulting mode to: hot')
+    args.mode = 'hot'
   }
 
   if (shouldExit) {
@@ -95,6 +102,10 @@ const initialize = (type = 'vue') => {
     fileID: args.fileID,
     clean: args.clean !== undefined ? args.clean : true,
     dest: args.dest !== undefined ? args.dest : undefined,
+    hmr: {
+      mode: args.watchMode || 'hot',
+      wsport: args.wsport || 8099
+    }
   }
 
   /* Vue watcher */

--- a/src/init.js
+++ b/src/init.js
@@ -104,8 +104,8 @@ const initialize = (type = 'vue') => {
     dest: args.dest !== undefined ? args.dest : undefined,
     hmr: {
       mode: args.watchMode || 'hot',
-      wsport: args.wsport || 8099
-    }
+      wsport: args.wsport || 8099,
+    },
   }
 
   /* Vue watcher */

--- a/src/init.js
+++ b/src/init.js
@@ -80,6 +80,8 @@ const showHelp = (type) => {
   if (type === 'vue') {
     // eslint-disable-next-line prettier/prettier
     clog('  --vueArgs', 'white', `- Inject arguments to vue-cli command ex: --vueArgs='--target="lib", --inline-vue'`)
+    clog('  --watchMode', 'white', `- Watcher mode for HMR, ex: hot | live | manual (default: hot)`)
+    clog('  --wsport', 'white', `- HMR server port, finds first available port starting from 8099 (default: 8099)`)
   }
 
   clog('\n  Check out documentation here: https://ui.pitcher.com/docs/guides/helper-packages/pitcher-watcher.html')

--- a/src/init.js
+++ b/src/init.js
@@ -23,10 +23,10 @@ const validateCommonArgs = () => {
   }
 
   // check mode
-  if (args.mode && !['hot', 'live', 'redirect', 'manual'].includes(args.mode)) {
-    warn(`[WARNING]: --mode=${args.mode} is invalid. Available arguments hot, live, redirect, manual`)
-    warn('[WARNING]: defaulting mode to: hot')
-    args.mode = 'hot'
+  if (args.watchMode && !['hot', 'live', 'redirect', 'manual'].includes(args.watchMode)) {
+    warn(`[WARNING]: --watchMode=${args.watchMode} is invalid. Available arguments hot, live, redirect, manual`)
+    warn('[WARNING]: defaulting watchMode to: hot')
+    args.watchMode = 'hot'
   }
 
   if (shouldExit) {

--- a/src/init.js
+++ b/src/init.js
@@ -70,6 +70,8 @@ const showHelp = (type) => {
   clog('  --no-clean', 'white', '- Disable copying after a change')
   // eslint-disable-next-line prettier/prettier
   clog('  --dest', 'white', '- Target folder to copy files [optional], NO NEED to use this unless you want to copy files to a static path')
+  clog('  --watchMode', 'white', `- Watcher mode for HMR, ex: hot | live | manual (default: hot)`)
+  clog('  --wsport', 'white', `- HMR server port, finds first available port starting from 8099 (default: 8099)`)
 
   if (type === 'watcher') {
     clog('  --paths', 'white', `- Paths to watch ex: --paths='src/, lib/' (default: '.')`)
@@ -82,8 +84,6 @@ const showHelp = (type) => {
   if (type === 'vue') {
     // eslint-disable-next-line prettier/prettier
     clog('  --vueArgs', 'white', `- Inject arguments to vue-cli command ex: --vueArgs='--target="lib", --inline-vue'`)
-    clog('  --watchMode', 'white', `- Watcher mode for HMR, ex: hot | live | manual (default: hot)`)
-    clog('  --wsport', 'white', `- HMR server port, finds first available port starting from 8099 (default: 8099)`)
   }
 
   clog('\n  Check out documentation here: https://ui.pitcher.com/docs/guides/helper-packages/pitcher-watcher.html')

--- a/src/init.js
+++ b/src/init.js
@@ -24,8 +24,8 @@ const validateCommonArgs = () => {
 
   // check mode
   if (args.watchMode && !['hot', 'live', 'manual'].includes(args.watchMode)) {
-    warn(`[WARNING]: --watchMode=${args.watchMode} is invalid. Available arguments hot, live, manual`)
-    warn('[WARNING]: defaulting watchMode to: hot')
+    warn(`--watchMode=${args.watchMode} is invalid. Available arguments hot, live, manual`)
+    warn('defaulting watchMode to: hot')
     args.watchMode = 'hot'
   }
 

--- a/src/prompts/index.js
+++ b/src/prompts/index.js
@@ -21,27 +21,6 @@ const iOS_deviceSelectionPrompt = (devices) => {
   })
 }
 
-const iOS_folderSelectionPrompt = (folders) => {
-  return new Promise((resolve) => {
-    inquirer
-      .prompt([
-        {
-          type: 'list',
-          name: 'folderSelection',
-          message: 'Select a folder: ',
-          default: folders[0],
-          choices: folders.map((f) => ({ name: `${f.name}`, value: f.value })),
-        },
-      ])
-      .then((answers) => {
-        return resolve(answers.folderSelection)
-      })
-      .catch((err) => {
-        throw new Error(`Something went wrong: ${err}`)
-      })
-  })
-}
-
 const win_driveSelectionPrompt = (drives) => {
   return new Promise((resolve) => {
     inquirer
@@ -84,9 +63,30 @@ const win_userSelectionPrompt = (users) => {
   })
 }
 
+const folderSelectionPrompt = (folders) => {
+  return new Promise((resolve) => {
+    inquirer
+      .prompt([
+        {
+          type: 'list',
+          name: 'folderSelection',
+          message: 'Select a folder: ',
+          default: folders[0],
+          choices: folders.map((f) => ({ name: `${f.name}`, value: f.value })),
+        },
+      ])
+      .then((answers) => {
+        return resolve(answers.folderSelection)
+      })
+      .catch((err) => {
+        throw new Error(`Something went wrong: ${err}`)
+      })
+  })
+}
+
 module.exports = {
   iOS_deviceSelectionPrompt,
-  iOS_folderSelectionPrompt,
   win_driveSelectionPrompt,
   win_userSelectionPrompt,
+  folderSelectionPrompt,
 }

--- a/src/prompts/index.js
+++ b/src/prompts/index.js
@@ -21,6 +21,27 @@ const iOS_deviceSelectionPrompt = (devices) => {
   })
 }
 
+const iOS_folderSelectionPrompt = (folders) => {
+  return new Promise((resolve) => {
+    inquirer
+      .prompt([
+        {
+          type: 'list',
+          name: 'folderSelection',
+          message: 'Select a folder: ',
+          default: folders[0],
+          choices: folders.map((f) => ({ name: `${f.name}`, value: f.value })),
+        },
+      ])
+      .then((answers) => {
+        return resolve(answers.folderSelection)
+      })
+      .catch((err) => {
+        throw new Error(`Something went wrong: ${err}`)
+      })
+  })
+}
+
 const win_driveSelectionPrompt = (drives) => {
   return new Promise((resolve) => {
     inquirer
@@ -65,6 +86,7 @@ const win_userSelectionPrompt = (users) => {
 
 module.exports = {
   iOS_deviceSelectionPrompt,
+  iOS_folderSelectionPrompt,
   win_driveSelectionPrompt,
   win_userSelectionPrompt,
 }

--- a/src/utils/file-system.js
+++ b/src/utils/file-system.js
@@ -61,9 +61,17 @@ const bashCopy = (sources, dest, ignored) => {
   })
 }
 
+// gets the folder name with parent folder name
+const getFolderNameWithparent = (path) => {
+  const secondLastIndex = path.lastIndexOf('/', path.lastIndexOf('/') - 1)
+
+  return path.substring(secondLastIndex + 1)
+}
+
 module.exports = {
   isDirEmpty,
   dirExist,
   cleanDirectory,
   bashCopy,
+  getFolderNameWithparent,
 }

--- a/src/utils/file-system.js
+++ b/src/utils/file-system.js
@@ -62,7 +62,7 @@ const bashCopy = (sources, dest, ignored = []) => {
 }
 
 // gets the folder name with parent folder name
-const getFolderNameWithparent = (path) => {
+const getFolderNameWithParent = (path) => {
   const secondLastIndex = path.lastIndexOf('/', path.lastIndexOf('/') - 1)
 
   return path.substring(secondLastIndex + 1)
@@ -73,5 +73,5 @@ module.exports = {
   dirExist,
   cleanDirectory,
   bashCopy,
-  getFolderNameWithparent,
+  getFolderNameWithParent,
 }

--- a/src/utils/file-system.js
+++ b/src/utils/file-system.js
@@ -40,7 +40,7 @@ const cleanDirectory = (path, showMessage = true) => {
   })
 }
 
-const bashCopy = (sources, dest, ignored) => {
+const bashCopy = (sources, dest, ignored = []) => {
   return new Promise((resolve) => {
     let excludeScript = ''
 
@@ -55,7 +55,7 @@ const bashCopy = (sources, dest, ignored) => {
         process.exit(1)
       }
 
-      log('copied files', 'grey')
+      log('copied files', 'magenta')
       resolve()
     })
   })

--- a/src/utils/ios-folder-finder.js
+++ b/src/utils/ios-folder-finder.js
@@ -1,7 +1,7 @@
 const { exec } = require('child_process')
 const { iOS_deviceSelectionPrompt, folderSelectionPrompt } = require('../prompts')
 const { log, error } = require('./logger')
-const { getFolderNameWithparent } = require('./file-system')
+const { getFolderNameWithParent } = require('./file-system')
 
 const findActiveDevices = () => {
   return new Promise((resolve) => {
@@ -57,7 +57,7 @@ const findSimulatorAppWorkingDirectory = (deviceID, fileID) =>
         .split('\n')
         .filter((p) => p)
         .map((p) => ({
-          name: getFolderNameWithparent(p),
+          name: getFolderNameWithParent(p),
           value: p,
         }))
 

--- a/src/utils/ios-folder-finder.js
+++ b/src/utils/ios-folder-finder.js
@@ -1,5 +1,5 @@
 const { exec } = require('child_process')
-const { iOS_deviceSelectionPrompt, iOS_folderSelectionPrompt } = require('../prompts')
+const { iOS_deviceSelectionPrompt, folderSelectionPrompt } = require('../prompts')
 const { log, error } = require('./logger')
 
 // gets the folder name with parent folder name
@@ -87,7 +87,7 @@ const findIOSAppDirectory = async (fileID) => {
 
   if (directories.length > 1) {
     log(`Found multiple folders that contains '${fileID}' in name`)
-    appDirectory = await iOS_folderSelectionPrompt(directories)
+    appDirectory = await folderSelectionPrompt(directories)
   } else if (directories.length === 1) {
     appDirectory = directories[0].value
   }

--- a/src/utils/ios-folder-finder.js
+++ b/src/utils/ios-folder-finder.js
@@ -36,34 +36,33 @@ const findActiveDevices = () => {
 
 const findSimulatorAppWorkingDirectory = (deviceID, fileID) =>
   new Promise((resolve, reject) => {
-    exec(
-      `find ~/Library/Developer/CoreSimulator/Devices/${deviceID} -type d -name "${fileID}*" -print`,
-      (err, stdout) => {
-        if (err) {
-          error(`Something went wrong: ${JSON.stringify(err)}`)
+    const searchPath = `~/Library/Developer/CoreSimulator/Devices/${deviceID}/data/Containers/Data/Application`
 
-          return reject(err)
-        }
+    exec(`find ${searchPath} -type d -name "${fileID}*" -print`, (err, stdout) => {
+      if (err) {
+        error(`Something went wrong: ${JSON.stringify(err)}`)
 
-        if (!stdout) {
-          error(`File ID: ${fileID}`)
-          error(`Device ID: ${deviceID}`)
-          error(`[ERROR]: Could not find a folder that contains ${fileID} in /Pitcher Folders/!`)
-          process.exit(1)
-        }
-
-        // map found folders
-        const paths = stdout
-          .split('\n')
-          .filter((p) => p)
-          .map((p) => ({
-            name: getFolderNameWithparent(p),
-            value: p,
-          }))
-
-        return resolve(paths)
+        return reject(err)
       }
-    )
+
+      if (!stdout) {
+        error(`File ID: ${fileID}`)
+        error(`Device ID: ${deviceID}`)
+        error(`[ERROR]: Could not find a folder that contains ${fileID} in /Pitcher Folders/!`)
+        process.exit(1)
+      }
+
+      // map found folders
+      const paths = stdout
+        .split('\n')
+        .filter((p) => p)
+        .map((p) => ({
+          name: getFolderNameWithparent(p),
+          value: p,
+        }))
+
+      return resolve(paths)
+    })
   })
 
 const findIOSAppDirectory = async (fileID) => {

--- a/src/utils/ios-folder-finder.js
+++ b/src/utils/ios-folder-finder.js
@@ -1,13 +1,7 @@
 const { exec } = require('child_process')
 const { iOS_deviceSelectionPrompt, folderSelectionPrompt } = require('../prompts')
 const { log, error } = require('./logger')
-
-// gets the folder name with parent folder name
-const getNameForSelection = (path) => {
-  const secondLastIndex = path.lastIndexOf('/', path.lastIndexOf('/') - 1)
-
-  return path.substring(secondLastIndex + 1)
-}
+const { getFolderNameWithparent } = require('./file-system')
 
 const findActiveDevices = () => {
   return new Promise((resolve) => {
@@ -63,7 +57,7 @@ const findSimulatorAppWorkingDirectory = (deviceID, fileID) =>
           .split('\n')
           .filter((p) => p)
           .map((p) => ({
-            name: getNameForSelection(p),
+            name: getFolderNameWithparent(p),
             value: p,
           }))
 

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -3,7 +3,7 @@ const chalk = require('chalk')
 const log = (msg, color = 'cyan') => console.log(chalk.white(`[@pitcher/watcher]:`, chalk[color](msg)))
 const clog = (msg, color = 'white', msg2 = '', color2 = 'cyan') => console.log(chalk[color](msg), chalk[color2](msg2))
 const error = (msg, color = 'red') => console.log(chalk[color](msg))
-const warn = (msg, color = 'yellow') => console.log(chalk[color](msg))
+const warn = (msg, color = 'yellow') => console.log(chalk[color](`[WARNING]: ${msg}`))
 
 module.exports = {
   log,

--- a/src/utils/port-finder.js
+++ b/src/utils/port-finder.js
@@ -1,0 +1,17 @@
+const portfinder = require('portfinder')
+const { error } = require('./logger')
+
+// eslint-disable-next-line consistent-return
+const getFreePort = async (port) => {
+  try {
+    return await portfinder.getPortPromise({
+      port, // minimum port
+      stopPort: port + 1000, // maximum port
+    })
+  } catch (e) {
+    error('[ERROR]: Something went wrong when trying to find a free port for HMR server!')
+    error(e)
+  }
+}
+
+module.exports = getFreePort

--- a/src/utils/win-folder-finder.js
+++ b/src/utils/win-folder-finder.js
@@ -2,7 +2,7 @@ const { exec } = require('child_process')
 const { readdir } = require('fs/promises')
 const { win_driveSelectionPrompt, win_userSelectionPrompt, folderSelectionPrompt } = require('../prompts')
 const { log, error, warn } = require('./logger')
-const { getFolderNameWithparent } = require('./file-system')
+const { getFolderNameWithParent } = require('./file-system')
 
 const MAX_BUFFER_SIZE = 2000 * 1024
 
@@ -103,7 +103,7 @@ const getWindowsWorkingDirectory = async (basePath, fileID) => {
         const fullPath = `${searchPath}/${folder}`
 
         return {
-          name: getFolderNameWithparent(fullPath),
+          name: getFolderNameWithParent(fullPath),
           value: fullPath,
         }
       })

--- a/src/utils/win-folder-finder.js
+++ b/src/utils/win-folder-finder.js
@@ -6,8 +6,8 @@ const { getFolderNameWithparent } = require('./file-system')
 
 const MAX_BUFFER_SIZE = 2000 * 1024
 
-
-const cliScript = `osascript -e 'tell application "Finder"' -e 'try' -e 'mount volume "smb://Guest:@Windows\ 10._smb._tcp.local/[C]\ Windows\ 10"' -e 'end try' -e 'end tell'`
+const drivePath = 'smb://Guest:@Windows 10._smb._tcp.local/[C] Windows 10'
+const cliScript = `osascript -e 'tell application "Finder"' -e 'try' -e 'mount volume "${drivePath}"' -e 'end try' -e 'end tell'`
 
 const mountParallelsDrive = () => {
   return new Promise((resolve) => {
@@ -21,7 +21,7 @@ const mountParallelsDrive = () => {
 
       // success
       log('Mounted Parallels VM as network drive succesfully')
-      
+
       return resolve(true)
     })
   })
@@ -32,7 +32,9 @@ const fetchDisks = () => {
     exec('/bin/df -H | grep "//"', { maxBuffer: MAX_BUFFER_SIZE }, (err, stdout) => {
       if (err) {
         error(`[ERROR]: Make sure you are running Parallels Machine and mounted the VM drive as network drive!`)
-        error(`[ERROR]: Check details on docs: https://ui.pitcher.com/docs/guides/helper-packages/pitcher-watcher.html#prerequisites`)
+        error(
+          `[ERROR]: Check details on docs: https://ui.pitcher.com/docs/guides/helper-packages/pitcher-watcher.html#prerequisites`
+        )
         error(`${JSON.stringify(err)}`)
         process.exit(1)
       }

--- a/src/vue.js
+++ b/src/vue.js
@@ -35,8 +35,7 @@ const execBuildWatch = async (vueArgs, destination, clean, hmr) => {
   if (clean) {
     await cleanDirectory(destination)
   }
-const service = new vueService(process.cwd())
-
+  const service = new vueService(process.cwd())
 
   // preview script
   const vueScript = 'vue-cli-service build --watch'

--- a/src/vue.js
+++ b/src/vue.js
@@ -41,7 +41,7 @@ const execBuildWatch = async (vueArgs, destination, clean, hmr) => {
 
   const hmrPluginOptions = {
     destination,
-    ...hmr
+    ...hmr,
   }
 
   // inject HMR plugin

--- a/src/vue.js
+++ b/src/vue.js
@@ -5,7 +5,6 @@ const { findIOSAppDirectory } = require('./utils/ios-folder-finder')
 const { findWindowsAppDirectory } = require('./utils/win-folder-finder')
 const { cleanDirectory } = require('./utils/file-system')
 const { log, error } = require('./utils/logger')
-const getFreePort = require('./utils/port-finder')
 const PitcherWatcherPlugin = require('./hmr')
 
 const execBuildWatch = async (vueArgs, destination, clean, hmr) => {
@@ -42,8 +41,7 @@ const execBuildWatch = async (vueArgs, destination, clean, hmr) => {
 
   const hmrPluginOptions = {
     destination,
-    mode: hmr.mode,
-    port: await getFreePort(hmr.wsport),
+    ...hmr
   }
 
   // inject HMR plugin
@@ -63,7 +61,7 @@ const execBuildWatch = async (vueArgs, destination, clean, hmr) => {
 
 ;(async () => {
   // initialize application and get args
-  const { platform, fileID, dest, clean, vueArgs, hmr } = initialize('vue')
+  const { platform, fileID, dest, clean, vueArgs, hmr } = await initialize('vue')
 
   try {
     // if user set the destination folder manually

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -42,7 +42,7 @@ const execWatcher = async (chokidarOpts, destination, fileID, clean, execAfter, 
         // move helper.js to destination & inject to index.html file
         await useHtmlInject(hmr, destination)
         // emit changes through websocket server
-        emitChangesToClients(socketServer.wss, hmr.mode, changedFiles)
+        emitChangesToClients(socketServer.ws, hmr.mode, changedFiles)
       }
 
       // clear changed file list copy operation

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -74,7 +74,7 @@ const execWatcher = async (chokidarOpts, destination, fileID, clean, execAfter, 
       copyTimer = setTimeout(() => {
         changedFiles.forEach((filePath) => log(`changed: ${filePath}`, 'yellow'))
         execAfterAction()
-      }, 600)
+      }, 500)
     })
     .on('ready', async () => {
       await execAfterAction()

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -5,24 +5,55 @@ const { initialize } = require('./init')
 const { findIOSAppDirectory } = require('./utils/ios-folder-finder')
 const { findWindowsAppDirectory } = require('./utils/win-folder-finder')
 const { cleanDirectory, bashCopy } = require('./utils/file-system')
+const { useHtmlInject, emitChangesToClients } = require('./hmr/legacy-hmr')
+const startWSServer = require('./hmr/socket-server')
 const { log, clog, error } = require('./utils/logger')
 
-const execWatcher = async (chokidarOpts, destination, fileID, clean, execAfter) => {
+const initialLog = (fileID, destination, paths) => {
+  console.log()
+  log('Waiting for changes...', 'green')
+  console.log()
+  clog('- File ID:', 'white', fileID, 'cyan')
+  clog('- Copy destination:', 'white', destination, 'cyan')
+  clog('- Watching paths:', 'white')
+  paths.forEach((p) => clog(`  - ${p}`, 'green'))
+  console.log()
+}
+
+// variable to store changed files, cleared after copy
+const changedFiles = new Set()
+
+const execWatcher = async (chokidarOpts, destination, fileID, clean, execAfter, hmr) => {
   const watcher = chokidar.watch(chokidarOpts.paths, chokidarOpts)
-  let timer = null
+  const isHotOrLive = ['hot', 'live'].includes(hmr.mode)
+  const socketServer = isHotOrLive ? startWSServer(hmr.port) : undefined
+  let copyTimer = null
 
   const execAfterAction = async () => {
     // clean directory before
     if (clean) await cleanDirectory(destination, false)
 
+    // default execute action after file changes
     if (!execAfter) {
-      bashCopy(chokidarOpts.paths, destination, chokidarOpts.ignored)
+      await bashCopy(chokidarOpts.paths, destination, chokidarOpts.ignored)
+
+      // if HMR is active
+      if (isHotOrLive) {
+        // move helper.js to destination & inject to index.html file
+        await useHtmlInject(hmr, destination)
+        // emit changes through websocket server
+        emitChangesToClients(socketServer.wss, hmr.mode, changedFiles)
+      }
+
+      // clear changed file list copy operation
+      changedFiles.clear()
 
       return
     }
 
+    // custom execute action after file changes
     exec(execAfter, (err) => {
-      log(`Executing script: ${execAfter}`, 'grey')
+      log(`Executing custom script: ${execAfter}`, 'grey')
       if (err) {
         error(`Something went wrong the script: ${execAfter}`)
         error(`${JSON.stringify(err)}`)
@@ -31,30 +62,23 @@ const execWatcher = async (chokidarOpts, destination, fileID, clean, execAfter) 
     })
   }
 
-  const initialLog = () => {
-    console.log()
-    log('Waiting for changes...', 'green')
-    console.log()
-    clog('- File ID:', 'white', fileID, 'cyan')
-    clog('- Copy destination:', 'white', destination, 'cyan')
-    clog('- Watching paths:', 'white')
-    chokidarOpts.paths.forEach((p) => clog(`  - ${p}`, 'green'))
-    console.log()
-  }
-
   // Event listeners
   watcher
     .on('unlink', (path) => log(`removed: ${path}`, 'red'))
     .on('change', async (path) => {
-      log(`changed: ${path}`, 'yellow')
+      changedFiles.add(path)
 
-      if (timer) clearTimeout(timer)
+      if (copyTimer) clearTimeout(copyTimer)
+
       // execute script with timeout, otherwise it is runned for each file change
-      timer = setTimeout(execAfterAction, 600)
+      copyTimer = setTimeout(() => {
+        changedFiles.forEach((filePath) => log(`changed: ${filePath}`, 'yellow'))
+        execAfterAction()
+      }, 600)
     })
-    .on('ready', () => {
-      execAfterAction()
-      initialLog()
+    .on('ready', async () => {
+      await execAfterAction()
+      initialLog(fileID, destination, chokidarOpts.paths)
     })
     .on('error', (err) => error(`[ERROR]: Watcher error: ${err}`))
 }
@@ -65,7 +89,7 @@ const execWatcher = async (chokidarOpts, destination, fileID, clean, execAfter) 
 
 ;(async () => {
   // initialize application and get args
-  const { platform, fileID, dest, clean, chokidarOpts, execAfter } = initialize('watcher')
+  const { platform, fileID, dest, clean, chokidarOpts, execAfter, hmr } = await initialize('watcher')
 
   try {
     // if user set the destination folder manually
@@ -80,7 +104,7 @@ const execWatcher = async (chokidarOpts, destination, fileID, clean, execAfter) 
     }
 
     // if everything is fine until this point, start watcher
-    await execWatcher(chokidarOpts, destination, fileID, clean, execAfter)
+    await execWatcher(chokidarOpts, destination, fileID, clean, execAfter, hmr)
   } catch (err) {
     error(err.message)
     process.exit(1)


### PR DESCRIPTION
### 📖  Description

- Simple socket server implementation to enable HMR
- Webpack plugin is written for HMR support
- Add support for hot reloading and live reloading the content inside simulator both for Windows and iOS (Supports Vue based projects and Legacy projects)
- Vue watcher now uses @vue/cli-service API instead of executing command from bash
- Let user to choose a folder, if multiple folders found under Pitcher Folders which contains same `fileID`
- Automount Parallels VM as a  network drive (no need to manually mount it anymore, depends on static VM name for now)
- Search path is more precise on macOS
- Docs to be updated on js-platform repo

- [x] Tested on iOS
- [x] Tested on Windows
- [x] Tested with Vue projects 
- [x] Tested with Legacy projects
