### PR TITLE
fix: add linkedom package to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "ip": "^1.1.5",
     "minimist": "^1.2.5",
     "portfinder": "^1.0.28",
-    "ws": "^8.5.0"
+    "ws": "^8.5.0",
+    "linkedom": "^0.14.3"
   },
   "peerDependencies": {
     "@vue/cli-service": "~4.3.0",


### PR DESCRIPTION
### 📖  Description
This pull request aims to add `linkedom` to package.json because if the device does not have this package, it throws an error (at least for legacy projects)

### ✅  Tested on iOS

### 📷  Screenshots

![Screen Shot 2022-03-03 at 13 00 27](https://user-images.githubusercontent.com/7488394/156541832-d7649da8-cd0b-4fa0-b611-2d5c347be707.png)
