### PR TITLE
fix: use spreading to append HMR plugin to provided array

### DIFF
--- a/src/vue.js
+++ b/src/vue.js
@@ -48,9 +48,8 @@ const execBuildWatch = async (vueArgs, destination, clean, hmr) => {
   // if plugins already exist, push the plugin
   // otherwise create an array which including the plugin
   service.projectOptions.configureWebpack = service.projectOptions.configureWebpack || {}
-  service.projectOptions.configureWebpack.plugins = service.projectOptions.configureWebpack.plugins
-    ? service.projectOptions.configureWebpack.plugins.push(new PitcherWatcherPlugin(hmrPluginOptions))
-    : [new PitcherWatcherPlugin(hmrPluginOptions)]
+  service.projectOptions.configureWebpack.plugins = service.projectOptions.configureWebpack.plugins || []
+  service.projectOptions.configureWebpack.plugins = [...service.projectOptions.configureWebpack.plugins, new PitcherWatcherPlugin(hmrPluginOptions)]
 
   // run build watch
   service.run('build', vueOptions)

--- a/src/vue.js
+++ b/src/vue.js
@@ -48,8 +48,7 @@ const execBuildWatch = async (vueArgs, destination, clean, hmr) => {
   // if plugins already exist, push the plugin
   // otherwise create an array which including the plugin
   service.projectOptions.configureWebpack = service.projectOptions.configureWebpack || {}
-  service.projectOptions.configureWebpack.plugins = service.projectOptions.configureWebpack.plugins || []
-  service.projectOptions.configureWebpack.plugins = [...service.projectOptions.configureWebpack.plugins, new PitcherWatcherPlugin(hmrPluginOptions)]
+  service.projectOptions.configureWebpack.plugins = [...service.projectOptions.configureWebpack.plugins || [], new PitcherWatcherPlugin(hmrPluginOptions)]
 
   // run build watch
   service.run('build', vueOptions)


### PR DESCRIPTION
When providing an array of plugins in Vue project, the watcher didn't work because it appended result of `.push()` method (which is a length – number – of updated array) to the array of plugins. 

This PR uses ES6's spread method to append HRM plugin. It works both with and without provided plugins by the user.