### PR TITLE
Feat/handle multiple pitcher folders

### DIFF
--- a/src/utils/win-folder-finder.js
+++ b/src/utils/win-folder-finder.js
@@ -98,14 +98,27 @@ const findUsers = async (drive) => {
 const getLocalStatePath = async (drive, user) => {
   const packagesPath = `${drive.path}/Users/${user}/AppData/Local/Packages`
   const packagesDir = await readdir(packagesPath)
-  const vayenFolderName = packagesDir.find((d) => d.includes('Vayen'))
+  const pitcherFolders = packagesDir.filter((d) => d.includes('Vayen'))
 
-  if (!vayenFolderName) {
+  if (!pitcherFolders.length) {
     error(`[ERROR]: Make sure you have installed Pitcher Impact on your Parallels machine!`)
     process.exit(1)
   }
 
-  return `${packagesPath}/${vayenFolderName}/LocalState`
+  let pitcherFolder = pitcherFolders[0]
+
+  if (pitcherFolders.length > 1) {
+    log(`Found multiple Pitcher folders`)
+    const mappedFolders = pitcherFolders.map((folder) => {
+        return {
+            name: folder,
+            value: folder,
+        }
+    })
+    pitcherFolder = await folderSelectionPrompt(mappedFolders)
+  }
+
+  return `${packagesPath}/${pitcherFolder}/LocalState`
 }
 
 // eslint-disable-next-line consistent-return

--- a/src/utils/win-folder-finder.js
+++ b/src/utils/win-folder-finder.js
@@ -110,10 +110,10 @@ const getLocalStatePath = async (drive, user) => {
   if (pitcherFolders.length > 1) {
     log(`Found multiple Pitcher folders`)
     const mappedFolders = pitcherFolders.map((folder) => {
-        return {
-            name: folder,
-            value: folder,
-        }
+      return {
+        name: folder,
+        value: folder,
+      }
     })
     pitcherFolder = await folderSelectionPrompt(mappedFolders)
   }

--- a/src/utils/win-folder-finder.js
+++ b/src/utils/win-folder-finder.js
@@ -115,6 +115,7 @@ const getLocalStatePath = async (drive, user) => {
         value: folder,
       }
     })
+
     pitcherFolder = await folderSelectionPrompt(mappedFolders)
   }
 


### PR DESCRIPTION
### Issue link
No ticket

### 📖  Description
When having both OG and UWP of Pitcher Impact installed, the watcher took first folder found, leaving a developer not being able to run it on another version. To address this issue, I've added a prompt for the user to select a folder.

- [x] Tested on Windows

### 📷  Screenshots
![prompt](https://user-images.githubusercontent.com/10488552/210228229-3cb5bd03-acbe-4378-b94b-e10a03b3d011.gif)
