### PR TITLE
fix: enhance regex to support parenthesis on the vm's name

### DIFF
--- a/src/utils/file-system.js
+++ b/src/utils/file-system.js
@@ -6,7 +6,7 @@ const isDirEmpty = (path) => fs.readdirSync(path).filter((f) => !/^\..*/.test(f)
 
 const dirExist = (path) => fs.existsSync(path)
 
-const fixPath = (path) => path.replace(/(\[|\]|\s)/g, '\\$&')
+const fixPath = (path) => path.replace(/(\[|\]|\(|\)|\s)/g, '\\$&')
 
 // cleaning with rm -rf
 // needs to be from bash because of the file system access rights on windows side


### PR DESCRIPTION

### 📖  Description
This pull request adds support for parenthesis on the VM's name

- [x] Tested on Windows

### 📷  Screenshots

![Screenshot 2023-01-24 at 10 54 01 AM](https://user-images.githubusercontent.com/5673119/214249716-5ffa0182-b5aa-4e17-aebc-7a144cf99d62.png)
![Screenshot 2023-01-24 at 10 55 42 AM](https://user-images.githubusercontent.com/5673119/214249725-64e93a38-3f1d-47b3-902c-829a2ba9b962.png)
