### PR TITLE
fix: clear intervals on before reload

### DIFF
--- a/src/hmr/hmr-helper.js
+++ b/src/hmr/hmr-helper.js
@@ -28,6 +28,15 @@ function removeCurrentFiles(fileList) {
     }
   });
 }
+function clearIntervals(){
+      // Get a reference to the last interval + 1
+      const interval_id = window.setInterval(function(){}, Number.MAX_SAFE_INTEGER);
+
+      // Clear any timeout/interval up to that id
+      for (let i = 1; i < interval_id; i++) {
+        window.clearInterval(i);
+      }
+}
 
 function injectNewFiles(fileList) {
   fileList.forEach(function (file) {
@@ -70,6 +79,8 @@ if (process.env.VUE_APP_HMR) {
     var data = _ref.data;
 
     var res = JSON.parse(data);
+    
+    clearIntervals()
 
     if (res.event === 'HOT_RELOAD') {
       console.log('[@pitcher/watcher]: page updated');

--- a/src/hmr/hmr-helper.js
+++ b/src/hmr/hmr-helper.js
@@ -33,7 +33,7 @@ function clearIntervals(){
       const interval_id = window.setInterval(function(){}, Number.MAX_SAFE_INTEGER);
 
       // Clear any timeout/interval up to that id
-      for (let i = 1; i < interval_id; i++) {
+      for (let i = 1; i <= interval_id; i++) {
         window.clearInterval(i);
       }
 }


### PR DESCRIPTION
### Issue link
https://pitcher.slack.com/archives/CR8V4UY81/p1703081252254759

### 📖  Description
This pull request is to fix the interval accumulation which causes debugging to get slower and slower on every pitcher-watcher reload.

- [ ] Tested on IOS

### 📷  Screenshots
#### 1) [CURRENT] See the console attached to a UI which is being pitcher-watched.
#### Pitcher watcher is being triggered couple of times.


https://github.com/PitcherAG/pitcher-watcher/assets/59139373/72c3858c-eb3f-480f-9dcc-796e5c748c74

#### 2) [AFTER-FIX] See a console attached to a UI which is being pitcher-watched.
#### Pitcher watcher is **again** being triggered couple of times.




https://github.com/PitcherAG/pitcher-watcher/assets/59139373/41f41c42-1e02-4798-acd7-37a74f562276


